### PR TITLE
Reduce memory footprint by using minimal console

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,8 @@
     "macros": ["MBED_CPU_STATS_ENABLED"],
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": 1
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-minimal-console-only": true
         }
     }
 }


### PR DESCRIPTION
Using minimal console provides RAM savings of up 185 bytes and
Flash savings of up to 1859 bytes.

### **DO NOT MERGE UNTIL THE MBED OS LIB IS UPDATED TO POINT TO A SHA THAT INCLUDES [THESE](https://github.com/ARMmbed/mbed-os/pull/11959) CHANGES.**