### PR TITLE
Deprecate the CPU usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This example is deprecated. The [mbed-os-example-cpu-stats](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-cpu-stats/) example shows how to use the `mbed_stats_cpu_get` API to print the CPU usage.**
+
 # Getting started with CPU Usage on Mbed OS
 
 This guide reviews the steps required to get CPU usage on Mbed OS platform.


### PR DESCRIPTION
This example and `mbed-os-example-cpu-stats` are showing the usage of `mbed_stats_cpu_get` API so `mbed-os-example-cpu-stats` is modified to calculate CPU usage from the statistics. 

# Note: 
`mbed-os-example-cpu-stats` changes in  [PR#52](https://github.com/ARMmbed/mbed-os-example-cpu-stats/pull/52)

#### Impact of changes
With this change, Mbed OS Documentation needs to be updated.
